### PR TITLE
develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,12 +353,12 @@ FLIP-FLOPS
 SR LATCH
 
 _A sr (set ready) latch is level-triggered and
-is the basic building block of all flip-flops.
+is the basic building block of other flip-flops._
 
 * **level-triggered**
 * The input s=0 sets the output to 1
 * The input r=0 resets the output to 0
-* Forms the basic building blocks of all other types of flip-flops
+* Forms the basic building blocks of other types of flip-flops
 
 |  s  |  r  |  q  | comment     |
 |:---:|:---:|:---:|:------------|

--- a/basic-code/sequential-logic/sr_latch/README.md
+++ b/basic-code/sequential-logic/sr_latch/README.md
@@ -1,7 +1,7 @@
 # SR LATCH EXAMPLE
 
 _A sr (set ready) latch is level-triggered and
-is the basic building block of all flip-flops._
+is the basic building block of other flip-flops._
 
 Table of Contents
 
@@ -36,7 +36,7 @@ SR LATCH
 * **level-triggered**
 * The input s=0 sets the output to 1
 * The input r=0 resets the output to 0
-* Forms the basic building blocks of all other types of flip-flops
+* Forms the basic building blocks of other types of flip-flops
 
 _I used
 [iverilog](https://github.com/JeffDeCola/my-cheat-sheets/tree/master/hardware/tools/simulation/iverilog-cheat-sheet)
@@ -72,7 +72,7 @@ repo._
 
 The
 [sr_latch.v](https://github.com/JeffDeCola/my-verilog-examples/blob/master/basic-code/sequential-logic/sr_latch/sr_latch.v)
-Gate model,
+gate model,
 
 ```verilog
     // NAND1
@@ -107,16 +107,19 @@ Behavioral model,
 
 ## RUN (SIMULATE)
 
-I created,
+The testbench uses two files,
 
 * [sr_latch_tb.v](https://github.com/JeffDeCola/my-verilog-examples/blob/master/basic-code/sequential-logic/sr_latch/sr_latch_tb.v)
   the testbench
 * [sr_latch_tb.tv](https://github.com/JeffDeCola/my-verilog-examples/blob/master/basic-code/sequential-logic/sr_latch/sr_latch_tb.tv)
   the test vectors and expected results
+
+where,
+
 * [sr_latch.vh](https://github.com/JeffDeCola/my-verilog-examples/blob/master/basic-code/sequential-logic/sr_latch/sr_latch.vh)
-  the header file listing the verilog code
+  is the header file listing the verilog models
 * [run-simulation.sh](https://github.com/JeffDeCola/my-verilog-examples/blob/master/basic-code/sequential-logic/sr_latch/run-simulation.sh)
-  a script containing the commands below
+  is a script containing the commands below
 
 Use **iverilog** to compile the verilog to a vvp format
 which is used by the vvp runtime simulation engine,
@@ -132,7 +135,7 @@ and creates a waveform dump file *.vcd.
 vvp sr_latch_tb.vvp
 ```
 
-The output,
+The output of the test,
 
 ```text
 TEST START --------------------------------
@@ -156,7 +159,7 @@ TEST START --------------------------------
 TEST END --------------------------------
 ```
 
-## CHECK WAVEFORM
+## VIEW WAVEFORM
 
 Open the waveform file sr_latch_tb.vcd file with GTKWave,
 
@@ -166,7 +169,7 @@ gtkwave -f sr_latch_tb.vcd &
 
 Save your waveform to a .gtkw file.
 
-Now you can
+Now you can use the script
 [launch-gtkwave.sh](https://github.com/JeffDeCola/my-verilog-examples/blob/master/launch-GTKWave-script/launch-gtkwave.sh)
 anytime you want,
 


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
