### PR TITLE
develop

### DIFF
--- a/basic-code/sequential-logic/d_flip_flop/README.md
+++ b/basic-code/sequential-logic/d_flip_flop/README.md
@@ -86,9 +86,9 @@ gate model,
     // INTERNAL WIRES
     wire        s, r;
     wire        s1, r1;
-  
+
     assign s = d;
-  
+
     // NOT1
     not (r, s);
 
@@ -101,7 +101,7 @@ gate model,
     nand (r1, r, clk);
 
     // SR-LATCH -------------------------------------
-    
+
     // NAND1
     nand (q, s1, qbar);
 
@@ -119,7 +119,7 @@ Dataflow model,
 
     // INTERNAL WIRES
     wire        s1, r1;
-  
+
     // NAND3
     assign s1 = ~(s & clk);
 
@@ -127,7 +127,7 @@ Dataflow model,
     assign r1 = ~(r & clk);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     assign q = ~(s1 & qbar);
 

--- a/basic-code/sequential-logic/d_flip_flop_pulse_triggered/README.md
+++ b/basic-code/sequential-logic/d_flip_flop_pulse_triggered/README.md
@@ -86,7 +86,7 @@ gate model,
     // INTERNAL WIRES
     wire        clk1;
 
-    //NOT 3  
+    //NOT 3
     not (clk1, clk);
 
     // D-FLIP FLOP (BOSS)
@@ -94,9 +94,9 @@ gate model,
         // INTERNAL WIRES
         wire        s1, r1;
         wire        s2, r2;
-      
+
         assign s1 = d;
-      
+
         // NOT2
         not (r1, s1);
 
@@ -109,7 +109,7 @@ gate model,
         nand (r2, r1, clk1);
 
         // SR-LATCH -------------------------------------
-        
+
         // NAND5
         nand (q1, s2, q1bar);
 
@@ -121,9 +121,9 @@ gate model,
         // INTERNAL WIRES
         wire        s3, r3;
         wire        s4, r4;
-      
+
         assign s3 = q1;
-      
+
         // NOT1
         not (r3, s3);
 
@@ -136,7 +136,7 @@ gate model,
         nand (r4, r3, clk1);
 
         // SR-LATCH -------------------------------------
-        
+
         // NAND1
         nand (q, s4, qbar);
 
@@ -150,7 +150,7 @@ Dataflow model,
     // INTERNAL WIRES
     wire        clk1;
 
-    // NOT3  
+    // NOT3
     assign clk1 = ~clk;
 
     // D-FLIP FLOP (BOSS)
@@ -158,9 +158,9 @@ Dataflow model,
         // INTERNAL WIRES
         wire        s1, r1;
         wire        s2, r2;
-      
+
         assign s1 = d;
-      
+
         // NOT2
         assign r1 = ~s1;
 
@@ -173,7 +173,7 @@ Dataflow model,
         assign r2 = ~(r1 & clk1);
 
         // SR-LATCH -------------------------------------
-        
+
         // NAND5
         assign q1 = ~( s2 & q1bar);
 
@@ -185,9 +185,9 @@ Dataflow model,
         // INTERNAL WIRES
         wire        s3, r3;
         wire        s4, r4;
-      
+
         assign s3 = q1;
-      
+
         // NOT1
         assign r3 = ~s3;
 
@@ -200,7 +200,7 @@ Dataflow model,
         assign r4 = ~(r3 & clk1);
 
         // SR-LATCH -------------------------------------
-        
+
         // NAND1
         assign q = ~(s4 & qbar);
 

--- a/basic-code/sequential-logic/jk_flip_flop/README.md
+++ b/basic-code/sequential-logic/jk_flip_flop/README.md
@@ -102,7 +102,7 @@ gate model,
 ```verilog
     // INTERNAL WIRES
     wire        s, r;
-  
+
     // NAND3
     nand (s, j, clk, qbar);
 
@@ -110,7 +110,7 @@ gate model,
     nand (r, k, clk, q);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     nand (q, s, qbar);
 
@@ -123,7 +123,7 @@ Dataflow model,
 ```verilog
     // INTERNAL WIRES
     wire        s, r;
-  
+
     // NAND3
     assign s = ~(j & clk & qbar);
 
@@ -131,7 +131,7 @@ Dataflow model,
     assign r = ~(k & clk & q);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     assign q = ~(s & qbar);
 

--- a/basic-code/sequential-logic/jk_flip_flop_pos_edge_sync_clear/README.md
+++ b/basic-code/sequential-logic/jk_flip_flop_pos_edge_sync_clear/README.md
@@ -133,7 +133,8 @@ Use **iverilog** to compile the verilog to a vvp format
 which is used by the vvp runtime simulation engine,
 
 ```bash
-iverilog -o jk_flip_flop_pos_edge_sync_clear_tb.vvp jk_flip_flop_pos_edge_sync_clear_tb.v jk_flip_flop_pos_edge_sync_clear.vh
+iverilog -o jk_flip_flop_pos_edge_sync_clear_tb.vvp \
+            jk_flip_flop_pos_edge_sync_clear_tb.v jk_flip_flop_pos_edge_sync_clear.vh
 ```
 
 Use **vvp** to run the simulation, which checks the UUT
@@ -148,7 +149,6 @@ The output of the test,
 ```text
 TEST START --------------------------------
 
-                                      
                  | TIME(ns) | CLRBAR | J | K |  Q  |
                  -----------------------------------
    0             |        0 |   1    | 0 | 0 |  x  |

--- a/basic-code/sequential-logic/jk_flip_flop_pulse_triggered/README.md
+++ b/basic-code/sequential-logic/jk_flip_flop_pulse_triggered/README.md
@@ -98,7 +98,7 @@ gate model,
         nand (r1, k, clk, q);
 
         // SR- LATCH -------------------------------------
-        
+
         // NAND6
         nand (q1, s1, q1bar);
 
@@ -114,7 +114,7 @@ gate model,
         nand (r2, q1bar, clk2);
 
         // SR- LATCH -------------------------------------
-        
+
         // NAND1
         nand (q, s2, qbar);
 
@@ -138,7 +138,7 @@ Dataflow model,
         assign r1 = ~(k & clk & q);
 
         // SR- LATCH -------------------------------------
-        
+
         // NAND6
         assign q1 = ~(s1 & q1bar);
 
@@ -154,7 +154,7 @@ Dataflow model,
         assign r2 = ~(q1bar & clk2);
 
         // SR- LATCH -------------------------------------
-        
+
         // NAND1
         assign q = ~(s2 & qbar);
 

--- a/basic-code/sequential-logic/sr_flip_flop/README.md
+++ b/basic-code/sequential-logic/sr_flip_flop/README.md
@@ -88,7 +88,7 @@ gate model,
 ```verilog
     // INTERNAL WIRES
     wire        s1, r1;
-  
+
     // NAND3
     nand (s1, s, clk);
 
@@ -96,7 +96,7 @@ gate model,
     nand (r1, r, clk);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     nand (q, s1, qbar);
 
@@ -109,7 +109,7 @@ Dataflow model,
 ```verilog
     // INTERNAL WIRES
     wire        s1, r1;
-  
+
     // NAND3
     assign s1 = ~(s & clk);
 
@@ -117,7 +117,7 @@ Dataflow model,
     assign r1 = ~(r & clk);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     assign q = ~(s1 & qbar);
 


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
- finished and2
- finished and2
- finished basic combinatorial logic
- updating flip-flops again
- updated readme
- finished d flip flop pulse triggered
- finished all flip-flops
- fixed readme typos
