### PR TITLE
develop

### DIFF
--- a/basic-code/sequential-logic/d_flip_flop_pos_edge_sync_en/README.md
+++ b/basic-code/sequential-logic/d_flip_flop_pos_edge_sync_en/README.md
@@ -117,7 +117,8 @@ Use **iverilog** to compile the verilog to a vvp format
 which is used by the vvp runtime simulation engine,
 
 ```bash
-iverilog -o d_flip_flop_pos_edge_sync_en_tb.vvp d_flip_flop_pos_edge_sync_en_tb.v d_flip_flop_pos_edge_sync_en.vh
+iverilog -o d_flip_flop_pos_edge_sync_en_tb.vvp \
+            d_flip_flop_pos_edge_sync_en_tb.v d_flip_flop_pos_edge_sync_en.vh
 ```
 
 Use **vvp** to run the simulation, which checks the UUT
@@ -132,7 +133,6 @@ The output of the test,
 ```text
 TEST START --------------------------------
 
-                               
                  | TIME(ns) | EN | D |  Q  |
                  ---------------------------
    0             |        0 | 1  | 0 |  x  |

--- a/basic-code/sequential-logic/jk_flip_flop_pulse_triggered/README.md
+++ b/basic-code/sequential-logic/jk_flip_flop_pulse_triggered/README.md
@@ -202,7 +202,8 @@ Use **iverilog** to compile the verilog to a vvp format
 which is used by the vvp runtime simulation engine,
 
 ```bash
-iverilog -o jk_flip_flop_pulse_triggered_tb.vvp jk_flip_flop_pulse_triggered_tb.v jk_flip_flop_pulse_triggered.vh
+iverilog -o jk_flip_flop_pulse_triggered_tb.vvp \
+            jk_flip_flop_pulse_triggered_tb.v jk_flip_flop_pulse_triggered.vh
 ```
 
 Use **vvp** to run the simulation, which checks the UUT

--- a/basic-code/sequential-logic/t_flip_flop/README.md
+++ b/basic-code/sequential-logic/t_flip_flop/README.md
@@ -107,7 +107,7 @@ gate model,
     nand (r, k, clk, q);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     nand (q, s, qbar);
 
@@ -122,7 +122,7 @@ Dataflow model,
     wire        s, r;
 
     // JK FLIP-FLOP -----------------------------------
-  
+
     // NAND3
     assign s = ~(t & clk & qbar);
 
@@ -130,7 +130,7 @@ Dataflow model,
     assign r = ~(t & clk & q);
 
     // SR- LATCH -------------------------------------
-    
+
     // NAND1
     assign q = ~(s & qbar);
 


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
- finished and2
- finished and2
- finished basic combinatorial logic
- updating flip-flops again
- updated readme
- finished d flip flop pulse triggered
- finished all flip-flops
- fixed readme typos
- fixed readme typos
