### PR TITLE
develop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,7 +22,10 @@ plugins:
     checks:
       # ... IGNORE INLINE HTML ...
       MD033:
-        enabled: false    
+        enabled: false
+      # ... IGNORE LINE LENGTH ...
+      MD013:
+        enabled: false
   shellcheck:
     enabled: true
 

--- a/README.md
+++ b/README.md
@@ -280,8 +280,7 @@ The artifacts created are,
 
   * [priority_arbiter](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/arbiters/priority_arbiter)
 
-    _A three level priority arbiter with asynchronous reset
-    (using if-then-else statements)._
+    _A three level priority arbiter with asynchronous reset._
 
 * COUNTERS
 

--- a/combinational-logic/data-operators/full_adder/.markdownlint.json
+++ b/combinational-logic/data-operators/full_adder/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD033": false,
+    "MD013": false
+}

--- a/combinational-logic/data-operators/full_adder/README.md
+++ b/combinational-logic/data-operators/full_adder/README.md
@@ -118,7 +118,7 @@ The output of the test,
 ```text
 TEST START --------------------------------
 
-                                            GATE -----   DATA -----   BEH ------  
+                                            GATE -----   DATA -----   BEH ------
                  | TIME(ns) | A | B | CIN | SUM | COUT | SUM | COUT | SUM | COUT |
                  -----------------------------------------------------------------
    0        INIT |        0 |  0  | 0 | 0 |  0   |  0  |  0   |  0  |  0   |  0  |


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
- finished and2
- finished and2
- finished basic combinatorial logic
- updating flip-flops again
- updated readme
- finished d flip flop pulse triggered
- finished all flip-flops
- fixed readme typos
- fixed readme typos
- updated 74x181
- updated 74x181
- updated 74x181 with test vectors and checking
- updated full adder
- updated full_adder
- updated half adder
- finished updating decoders and encoders
- added mux and demux
- revamped mux_to_demux
- revamped mux_to_demux
- revampes 74x151
- revamped 74x157
- I like encoder to decoder better
- fixing codeclimate errors
