### PR TITLE
develop

### DIFF
--- a/sequential-logic/counters/jeff_74x161/README.md
+++ b/sequential-logic/counters/jeff_74x161/README.md
@@ -4,11 +4,6 @@ _Synchronous presettable 4-bit binary counter, asynchronous clear.
 Based on the 7400-series integrated circuits used in my
 [programable_8_bit_microprocessor](https://github.com/JeffDeCola/my-verilog-examples/tree/master/systems/microprocessors/programable_8_bit_microprocessor)._
 
-Documentation and Reference
-
-* I'm using my
-  [jk_flip_flop_pos_edge_sync_clear](https://github.com/JeffDeCola/my-verilog-examples/tree/master/basic-code/sequential-logic/jk_flip_flop_pos_edge_sync_clear)
-
 Table of Contents
 
 * [OVERVIEW](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/counters/jeff_74x161#overview)
@@ -18,6 +13,11 @@ Table of Contents
 * [RUN (SIMULATE)](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/counters/jeff_74x161#run-simulate)
 * [VIEW WAVEFORM](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/counters/jeff_74x161#view-waveform)
 * [TESTED IN HARDWARE - BURNED TO A FPGA](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/counters/jeff_74x161#tested-in-hardware---burned-to-a-fpga)
+
+Documentation and Reference
+
+* I'm using my
+  [jk_flip_flop_pos_edge_sync_clear](https://github.com/JeffDeCola/my-verilog-examples/tree/master/basic-code/sequential-logic/jk_flip_flop_pos_edge_sync_clear)
 
 ## OVERVIEW
 
@@ -41,11 +41,11 @@ The `clr_bar` is connected directly to the JK flip-flops.
 ## TRUTH TABLE
 
 | clr_bar | ld_bar | ent | enp | d | c | b | a | qd | qc  | qb  | qa  | rco | COMMENT |
-|:-------:|:------:|:---:|:---:|:-:|:-:|:-:|:-:|:--:|:---:|:---:|:---:|:---:|:-------:|
-|    1    |    1   |  0  |  0  | x | x | x | x | qd | qc  | qb  | qa  | rco | WAIT   :|
-|    0    |    1   |  0  |  0  | x | x | x | x | 0  | 0   | 0   | 0   |  0  | CLEAR  :|
-|    1    |    0   |  0  |  0  | d | c | b | a | d  | c   | b   | a   |  0  | LOAD   :|
-|    1    |    1   |  1  |  1  | x | x | x | x | +  | +   | +   | +   |  0  | COUNT  :|
+|:-------:|:------:|:---:|:---:|:-:|:-:|:-:|:-:|:--:|:---:|:---:|:---:|:---:|:--------|
+|    1    |    1   |  0  |  0  | x | x | x | x | qd | qc  | qb  | qa  | rco | WAIT    |
+|    0    |    1   |  0  |  0  | x | x | x | x | 0  | 0   | 0   | 0   |  0  | CLEAR   |
+|    1    |    0   |  0  |  0  | d | c | b | a | d  | c   | b   | a   |  0  | LOAD    |
+|    1    |    1   |  1  |  1  | x | x | x | x | +  | +   | +   | +   |  0  | COUNT   |
 
 ## VERILOG CODE
 


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
- finished and2
- finished and2
- finished basic combinatorial logic
- updating flip-flops again
- updated readme
- finished d flip flop pulse triggered
- finished all flip-flops
- fixed readme typos
- fixed readme typos
- updated 74x181
- updated 74x181
- updated 74x181 with test vectors and checking
- updated full adder
- updated full_adder
- updated half adder
- finished updating decoders and encoders
- added mux and demux
- revamped mux_to_demux
- revamped mux_to_demux
- revampes 74x151
- revamped 74x157
- I like encoder to decoder better
- fixing codeclimate errors
- revamped priority arbiter
- revamped 74x161
- updated readme
