### PR TITLE
develop

### DIFF
--- a/sequential-logic/memory/dual_port_ram_asynchronous/README.md
+++ b/sequential-logic/memory/dual_port_ram_asynchronous/README.md
@@ -85,8 +85,10 @@ The testbench uses two files,
 
 * [dual_port_ram_asynchronous_tb.v](https://github.com/JeffDeCola/my-verilog-examples/blob/master/sequential-logic/memory/dual_port_ram_asynchronous/dual_port_ram_asynchronous_tb.v)
   the testbench
-* [dual_port_ram_asynchronous_tb.tv](https://github.com/JeffDeCola/my-verilog-examples/blob/master/sequential-logic/memory/dual_port_ram_asynchronous/dual_port_ram_asynchronous_tb.tv)
-  the test vectors and expected results
+* [dual_port_ram_asynchronous_tb_A.tv](https://github.com/JeffDeCola/my-verilog-examples/blob/master/sequential-logic/memory/dual_port_ram_asynchronous/dual_port_ram_asynchronous_tb_A.tv)
+  the test vectors for clk_A and expected results
+* [dual_port_ram_asynchronous_tb_B.tv](https://github.com/JeffDeCola/my-verilog-examples/blob/master/sequential-logic/memory/dual_port_ram_asynchronous/dual_port_ram_asynchronous_tb_B.tv)
+  the test vectors for clk_B and expected results
 
 with,
 
@@ -109,7 +111,7 @@ and creates a waveform dump file *.vcd.
 vvp dual_port_ram_asynchronous_tb.vvp
 ```
 
-The output of the test,
+The test uses two different clocks (CLK_A and CLK_B). The output of the test,
 
 ```text
 TEST START --------------------------------


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
- finished and2
- finished and2
- finished basic combinatorial logic
- updating flip-flops again
- updated readme
- finished d flip flop pulse triggered
- finished all flip-flops
- fixed readme typos
- fixed readme typos
- updated 74x181
- updated 74x181
- updated 74x181 with test vectors and checking
- updated full adder
- updated full_adder
- updated half adder
- finished updating decoders and encoders
- added mux and demux
- revamped mux_to_demux
- revamped mux_to_demux
- revampes 74x151
- revamped 74x157
- I like encoder to decoder better
- fixing codeclimate errors
- revamped priority arbiter
- revamped 74x161
- updated readme
- added ci pipeline
- updated finite state machines to mealy and moore
- added mealy and moore finite state machines
- revamped simple_memory_using_1d_array
- revamped 74x377 register
- revamped SIMPLE 8-BIT REGISTER EXAMPLE
- revampled left shift register
- revamped simple pipeline
- working on revamping my 8-bit uproc
- working on revamping my 8-bit uproc
- working on revamping my 8-bit uproc
- completed microprocessor
- revamped buttons
- removed rogue file
- created single and dual port sync RAM
- updating memory examples
- added dual-port asynchronous RAM
- added dual-port asynchronous RAM
- typo
- updated dual-port async RAM README
