### PR TITLE
develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,25 +308,29 @@ The artifacts created are,
 
     _Single-port synchronous RAM._
 
-  * [dual_port_ram_asynchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/dual_port_ram_asynchronous)
-
-    _Dual-port asynchronous RAM using two different clocks._
-
   * [dual_port_ram_synchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/dual_port_ram_synchronous)
 
     _Dual-port synchronous RAM._
 
-  * [fifo_asynchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/fifo_asynchronous)
+  * [dual_port_ram_asynchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/dual_port_ram_asynchronous)
 
-    _An asynchronous fifo using dual-port asynchronous RAM._
+    _Dual-port asynchronous RAM using two different clocks._
 
   * [fifo_synchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/fifo_synchronous)
 
     _A synchronous fifo using dual-port synchronous RAM._
 
+  * [fifo_asynchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/fifo_asynchronous)
+
+    _An asynchronous fifo using dual-port asynchronous RAM._
+
   * [lifo_synchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/lifo_synchronous)
 
-    _A synchronous lifo._
+    _A synchronous lifo using dual-port synchronous RAM._
+
+  * [lifo_asynchronous](https://github.com/JeffDeCola/my-verilog-examples/tree/master/sequential-logic/memory/lifo_asynchronous)
+
+    _An asynchronous lifo using dual-port asynchronous RAM._
 
 * REGISTERS
 


### PR DESCRIPTION
- udpated launch gtkwave script and codeclimate ignore inline html
- updating all README files
- udpated and2 with new README verbiage
- figuring out the example readme file verbiage
- figuring out the example readme file verbiage
- changing filenames to reflect module names
- update and_gates
- finished overhaul of and2 and and_gates
- changing hyphen in filenames to underscore
- major update with file names and READMEs
- updated run-simulation and launch scripts
- fixed README typos
- updated all testbenches
- updating files in basic-code
- adding latchs and flip-flops
- adding latchs and flip-flops
- updated links
- typo link
- update and
- scaling .svg images
- testing svg image size
- latex renders of combination gates
- added schematic pics to combinational logic
- starting to work on flip-flops
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating latch and flip-flop pics
- updating sr latch and flip flop. Creating new test bench using vectors
- updating testbenches and flip-flops
- updating readme
- fixing stale links
- updating latches and flip-flops
- updating latches and flip-flops
- finished and2
- finished and2
- finished basic combinatorial logic
- updating flip-flops again
- updated readme
- finished d flip flop pulse triggered
- finished all flip-flops
- fixed readme typos
- fixed readme typos
- updated 74x181
- updated 74x181
- updated 74x181 with test vectors and checking
- updated full adder
- updated full_adder
- updated half adder
- finished updating decoders and encoders
- added mux and demux
- revamped mux_to_demux
- revamped mux_to_demux
- revampes 74x151
- revamped 74x157
- I like encoder to decoder better
- fixing codeclimate errors
- revamped priority arbiter
- revamped 74x161
- updated readme
- added ci pipeline
- updated finite state machines to mealy and moore
- added mealy and moore finite state machines
- revamped simple_memory_using_1d_array
- revamped 74x377 register
- revamped SIMPLE 8-BIT REGISTER EXAMPLE
- revampled left shift register
- revamped simple pipeline
- working on revamping my 8-bit uproc
- working on revamping my 8-bit uproc
- working on revamping my 8-bit uproc
- completed microprocessor
- revamped buttons
- removed rogue file
- created single and dual port sync RAM
- updating memory examples
- added dual-port asynchronous RAM
- added dual-port asynchronous RAM
- typo
- updated dual-port async RAM README
- updated README
